### PR TITLE
ci(helm): bump Trivy version to 0.56.2

### DIFF
--- a/helm/trivy/Chart.yaml
+++ b/helm/trivy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: trivy
-version: 0.8.0
-appVersion: 0.55.0
+version: 0.56.2
+appVersion: 0.56.2
 description: Trivy helm chart
 keywords:
   - scanner


### PR DESCRIPTION
This PR bumps Trivy up to the 0.56.2 version for the Helm chart.